### PR TITLE
Add a VSCode setting to "draw anything other than a single white space character that separates words".

### DIFF
--- a/Library/ApplicationSupport/Code/User/settings.json
+++ b/Library/ApplicationSupport/Code/User/settings.json
@@ -34,6 +34,7 @@
   // -----------------------------------
   "editor.minimap.enabled": false,
   "editor.lineNumbers": "relative",
+  "editor.renderWhitespace": "boundary",
 
   // -- Font
   "editor.fontFamily": "'HackGen35 Console NF'",
@@ -345,7 +346,7 @@
   "intelephense.diagnostics.undefinedFunctions": false,
   "intelephense.diagnostics.undefinedMethods": false,
   "intelephense.diagnostics.undefinedTypes": false,
-  "intelephense.format.braces": "k&r"
+  "intelephense.format.braces": "k&r",
 
   // Markdown
   // -----------------------------------


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add a VSCode setting to "draw anything other than a single white space character that separates words".