### PR TITLE
To change the Node.js version control tool from nvm to Volta, delete the nvm settings.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,4 @@
+[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+
+export VOLTA_HOME="$HOME/.volta"
+export PATH="$VOLTA_HOME/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -233,7 +233,3 @@ export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
 
 export TERM=xterm-256color
-
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

